### PR TITLE
Improve jiff.clone

### DIFF
--- a/lib/clone.js
+++ b/lib/clone.js
@@ -1,34 +1,45 @@
-var jsonDateRx = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}(?:\.\d*)?)(Z|([+\-])(\d{2}):(\d{2}))$/;
+/** @license MIT License (c) copyright 2010-2014 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
 
 /**
- * Create a deep copy of x which must be a value JSON object/array/value
+ * Create a deep copy of x which must be a legal JSON object/array/value
  * @param {object|array|string|number|null} x object/array/value to clone
  * @returns {object|array|string|number|null} clone of x
  */
-module.exports = function clone(x) {
-	return x !== null && typeof x === 'object'
-		? JSON.parse(JSON.stringify(x), dateReviver)
-		: x;
-};
+module.exports = clone;
 
-/**
- * Deserialize dates from JSON
- * @param _
- * @param {*} value ISO date string
- * @returns {*|Date} returns parsed Date, or value if value is not a
- *  valid ISO date string
- */
-function dateReviver(_, value) {
-	var match;
-
-	if (typeof value === 'string') {
-		match = jsonDateRx.exec(value);
-		if (match) {
-			return new Date(Date.UTC(
-					+match[1], +match[2] - 1, +match[3], +match[4], +match[5], +match[6])
-			);
-		}
+function clone(x) {
+	if(x == null || typeof x !== 'object') {
+		return x;
 	}
 
-	return value;
+	if(Array.isArray(x)) {
+		return cloneArray(x);
+	}
+
+	return cloneObject(x);
+}
+
+function cloneArray (x) {
+	var l = x.length;
+	var y = new Array(l);
+
+	for (var i = 0; i < l; ++i) {
+		y[i] = clone(x[i]);
+	}
+
+	return y;
+}
+
+function cloneObject (x) {
+	var keys = Object.keys(x);
+	var y = {};
+
+	for (var k, i = 0, l = keys.length; i < l; ++i) {
+		k = keys[i];
+		y[k] = clone(x[k]);
+	}
+
+	return y;
 }


### PR DESCRIPTION
This commit switches from using JSON.stringify + JSON.parse to a brute
force, recursive copy.  This seems to have 2 advantages:
1. It doesn't use the custom date reviver, which causes ISO date
   strings to magically become Date objects _during patching_, which is
   surprising.  IOW, if a patch contains an ISO date string, under
   certain conditions that resulting patched object will contain a Date
   object instead of a string.
2. It appears anywhere from 3-5 faster, at least on v8, than
   JSON.stringify + JSON.parse.

Fix #22 
