### PR TITLE
Make `add` operations check array bounds

### DIFF
--- a/lib/patches.js
+++ b/lib/patches.js
@@ -128,6 +128,8 @@ function _add(pointer, value) {
 		// '-' indicates 'append' to array
 		if(pointer.key === '-') {
 			target.push(value);
+		} else if (pointer.key > array.length) {
+			throw new InvalidPatchOperationError('target of add outside of array bounds')
 		} else {
 			target.splice(pointer.key, 0, value);
 		}


### PR DESCRIPTION
From section 4.1 of the RFC:

> The specified index MUST NOT be greater than the number of elements in the array.

This caught me out as doing `get("/foo/1", patch([{"op": "add", "path": "/foo/1", "value": "bar"}], {foo: []}))` would fail in the `get` instead of the `patch`.