### PR TITLE
use JSON.stringify as default hash for all non-primitive array elements

### DIFF
--- a/lib/jsonPatch.js
+++ b/lib/jsonPatch.js
@@ -56,9 +56,13 @@ function patchInPlace(changes, x, options) {
 }
 
 function defaultHash(x) {
-	return isValidObject(x) ? JSON.stringify(x) : x;
+	return isValidObject(x) || isArray(x) ? JSON.stringify(x) : x;
 }
 
 function isValidObject (x) {
 	return x !== null && Object.prototype.toString.call(x) === '[object Object]';
+}
+
+function isArray (x) {
+	return Object.prototype.toString.call(x) === '[object Array]';
 }

--- a/test/jiff-test.js
+++ b/test/jiff-test.js
@@ -1,6 +1,7 @@
 var buster = require('buster');
 require('gent/test-adapter/buster');
 var assert = buster.referee.assert;
+var refute = buster.referee.refute;
 var gent = require('gent');
 var json = require('gent/generator/json');
 var deepEquals = require('../lib/deepEquals');
@@ -91,6 +92,34 @@ buster.testCase('jiff', {
 				assert.equals(patch[0].op, 'add');
 				assert(patch[0].path === '/-' || patch[0].path === '/0');
 				assert.same(patch[0].value, 1);
+			},
+			'with default hash function': {
+				'primitives as elements': {
+					'should generate an empty patch when elements are equal': function() {
+						var patch = jiff.diff([1,'a',true], [1,'a',true]);
+						assert.equals(patch.length, 0);
+					}
+				},
+				'arrays as elements': {
+					'should generate an empty patch when elements are equal': function() {
+						var patch = jiff.diff([['a'],['b'],['c']], [['a'],['b'],['c']]);
+						assert.equals(patch.length, 0);
+					}
+				},
+				'objects as elements': {
+					'object keys with consistent order': {
+						'should generate an empty patch when elements are equal': function() {
+							var patch = jiff.diff([{a:'a',b:'b',c:'c'}], [{a:'a',b:'b',c:'c'}]);
+							assert.equals(patch.length, 0);
+						}
+					},
+					'object keys with inconsistent order': {
+						'should generate a non empty patch even though elements are equal': function() {
+							var patch = jiff.diff([{b:'b',c:'c',a:'a'}], [{a:'a',b:'b',c:'c'}]);
+							refute.equals(patch.length, 0);
+						}
+					}
+				}
 			}
 		},
 

--- a/test/jiff-test.js
+++ b/test/jiff-test.js
@@ -49,6 +49,38 @@ buster.testCase('jiff', {
 				json.array(1, json.object()),
 				json.array(1, json.object())
 			);
+		},
+
+		'for arrays of arrays': function() {
+			assert(deepEqualAfterDiffPatch()(
+				[['a'],['b'],['c']],
+				[['b']]
+			));
+
+			assert(deepEqualAfterDiffPatch()(
+				[['a']],
+				[['b']]
+			));
+
+			assert(deepEqualAfterDiffPatch()(
+				[['a'],['b'],['c']],
+				[['d']]
+			));
+
+			assert(deepEqualAfterDiffPatch()(
+				[['b']],
+				[['a'],['b'],['c']]
+			));
+
+			assert(deepEqualAfterDiffPatch()(
+				[['d']],
+				[['a'],['b'],['c']]
+			));
+
+			assert.claim(deepEqualAfterDiffPatch(),
+				json.array(1, json.array()),
+				json.array(1, json.array())
+			);
 		}
 	},
 


### PR DESCRIPTION
following discussion at #32 

@briancavalier this was an easy enough change. Please feel free to reject if you don't agree with my suggestion.