### PR TITLE
fix array replace

### DIFF
--- a/test/jiff-test.js
+++ b/test/jiff-test.js
@@ -93,6 +93,16 @@ buster.testCase('jiff', {
 				assert(patch[0].path === '/-' || patch[0].path === '/0');
 				assert.same(patch[0].value, 1);
 			},
+			'should coalesce add adjacent remove into replace': function() {
+				var patch = jiff.diff(['a', 'b', 'c'], ['a', 'z', 'c']);
+				assert.equals(patch.length, 2);
+				assert.equals(patch[0].op, 'test');
+				assert.equals(patch[0].path, '/1');
+				assert.equals(patch[0].value, 'b');
+				assert.equals(patch[1].op, 'replace');
+				assert.equals(patch[1].path, '/1');
+				assert.equals(patch[1].value, 'z');
+			},
 			'with default hash function': {
 				'primitives as elements': {
 					'should generate an empty patch when elements are equal': function() {


### PR DESCRIPTION
This fixes the feature whereby an add op followed immediately by a remove op are coalesced into a replace op.

Consider `Jiff.diff(["a", "b", "c"], ["a", "b", "z"]);`

Before this fix:

``` json
[
  {
    "op": "add",
    "path": "/2",
    "value": "z"
  },
  {
    "op": "test",
    "path": "/3",
    "value": "c"
  },
  {
    "op": "remove",
    "path": "/3"
  }
]

```

After this fix:

``` json
[
  {
    "op": "test",
    "path": "/2",
    "value": "c"
  },
  {
    "op": "replace",
    "path": "/2",
    "value": "z"
  }
]

```
