### PR TITLE
Fix/coalesce adjacent remove add into replace

### DIFF
--- a/jiff.js
+++ b/jiff.js
@@ -168,7 +168,7 @@ function lcsToJsonPatch(a1, a2, path, state, lcsMatrix) {
 				last.context = context;
 				// Insert a test before the replace operation in case invertible is true
 				if(state.invertible) {
-					patch.splice(patch.length - 2, 0, { op: 'test', path: prevP, value: a1[j], context: context })
+					patch.splice(patch.length - 1, 0, { op: 'test', path: prevP, value: a1[j], context: context })
 				}
 			} else {
 				if(state.invertible) {

--- a/jiff.js
+++ b/jiff.js
@@ -161,15 +161,19 @@ function lcsToJsonPatch(a1, a2, path, state, lcsMatrix) {
 			// Coalesce adjacent remove + add into replace
 			last = patch[patch.length-1];
 			context = state.makeContext(j, a1);
+			prevP = path + '/' + (j + (offset - 1));
 
-			if(state.invertible) {
-				patch.push({ op: 'test', path: p, value: a1[j], context: context });
-			}
-
-			if(last !== void 0 && last.op === 'add' && last.path === p) {
+			if(last !== void 0 && last.op === 'add' && last.path === prevP) {
 				last.op = 'replace';
 				last.context = context;
+				// Insert a test before the replace operation in case invertible is true
+				if(state.invertible) {
+					patch.splice(patch.length - 2, 0, { op: 'test', path: prevP, value: a1[j], context: context })
+				}
 			} else {
+				if(state.invertible) {
+					patch.push({ op: 'test', path: p, value: a1[j], context: context });
+				}
 				patch.push({ op: 'remove', path: p, context: context });
 			}
 

--- a/test/jiff-test.js
+++ b/test/jiff-test.js
@@ -120,6 +120,15 @@ buster.testCase('jiff', {
 						}
 					}
 				}
+			},
+			'should generate replace': function() {
+				var a = [1, 2];
+				var b = [3, 2];
+
+				var patch = jiff.diff(a, b, { invertible: false });
+				assert.equals(patch.length, 1);
+				assert.equals(patch[0].op, 'replace');
+				assert.equals(b, jiff.patch(patch, a));
 			}
 		},
 

--- a/test/jiff-test.js
+++ b/test/jiff-test.js
@@ -125,9 +125,10 @@ buster.testCase('jiff', {
 				var a = [1, 2];
 				var b = [3, 2];
 
-				var patch = jiff.diff(a, b, { invertible: false });
-				assert.equals(patch.length, 1);
-				assert.equals(patch[0].op, 'replace');
+				var patch = jiff.diff(a, b, { invertible: true });
+				assert.equals(patch.length, 2);
+				assert.equals(patch[0].op, 'test');
+				assert.equals(patch[1].op, 'replace');
 				assert.equals(b, jiff.patch(patch, a));
 			}
 		},


### PR DESCRIPTION
Comparision of path for adjacent add + remove operation was broken when offset functionality was introduced

Test case
```js
let jif = require('jiff');
let a = [1,2,3];
let b = [4,2,3];
console.log(jif.diff(a, b, {invertible:false}));
```
Result
```
Array (2 items)
0: Object {context: undefined, op: "add", path: "/0", value: 4}
1: Object {context: undefined, op: "remove", path: "/1"}
```
Expected Result
```
Array (1 item)
0: Object {context: undefined, op: "replace", path: "/0", value: 4}
```

Signed-off-by: Manish Bhatia <manish@giveindia.org>