### PR TITLE
Add missing hash call in diff calculation

### DIFF
--- a/jiff.js
+++ b/jiff.js
@@ -202,7 +202,7 @@ function lcsToJsonPatch(a1, a2, path, state, lcsMatrix) {
  * @returns {object} updated diff state
  */
 function appendValueChanges(a, b, path, state) {
-	if(a !== b) {
+	if(state.hash(a) !== state.hash(b)) {
 		if(state.invertible) {
 			state.patch.push({ op: 'test', path: path, value: a });
 		}

--- a/test/jiff-test.js
+++ b/test/jiff-test.js
@@ -120,6 +120,60 @@ buster.testCase('jiff', {
 						}
 					}
 				}
+			},
+			'with custom hash function': {
+				'primitives as elements': {
+					'should generate an empty patch when elements are equal': function() {
+						var patch = jiff.diff([1, 'a', true], [1, 'a', true], {
+							hash: function (a) {
+								return JSON.stringify(a) + '_SUFFIX';
+							}
+						});
+						assert.equals(patch.length, 0);
+					}
+				},
+				'arrays as elements': {
+					'should generate an empty patch when elements are equal': function() {
+						var patch = jiff.diff([['a'], ['b'], ['c']], [['a'], ['b'], ['c']], {
+							hash: function (a) {
+								return JSON.stringify(a) + '_SUFFIX';
+							}
+						});
+						assert.equals(patch.length, 0);
+					}
+				},
+				'objects as elements': {
+					'object keys with consistent order': {
+						'should generate an empty patch when elements are equal': function() {
+							var patch = jiff.diff([{a: 'a', b: 'b', c: 'c'}], [{a: 'a', b: 'b', c: 'c'}], {
+								hash: function (a) {
+									return JSON.stringify(a) + '_SUFFIX';
+								}
+							});
+							assert.equals(patch.length, 0);
+						}
+					},
+					'object keys with inconsistent order': {
+						'should generate a non empty patch even though elements are equal': function() {
+							var patch = jiff.diff([{b: 'b', c: 'c', a: 'a'}], [{a: 'a', b: 'b', c: 'c'}], {
+								hash: function (a) {
+									return JSON.stringify(a) + '_SUFFIX';
+								}
+							});
+							refute.equals(patch.length, 0);
+						}
+					}
+				},
+				'when custom hash ignores value': function() {
+					var patch = jiff.diff([1], [2], {
+						invertible: false,
+						hash: function (a) {
+							return typeof a;
+						}
+					});
+
+					assert.equals(patch.length, 0);
+				}
 			}
 		},
 


### PR DESCRIPTION
Currently `jiff.diff()`, despite taking the `hash` function as an argument, does not call it. 

Fixing this enables the user to supply a custom hash function enabling unified behaviour across all jiff functions.

Tests updated reflect this with a basic example (only compare the type of the field rather than its value).  If you wish for another example let me know, happy to create